### PR TITLE
Fix for game winner detection.

### DIFF
--- a/src/TicTacToeInverted.java
+++ b/src/TicTacToeInverted.java
@@ -14,7 +14,12 @@ public class TicTacToeInverted extends Game{
     boolean isGameOver() {
         // Comprobar si hay un ganador
         if (isLoser()) {
-            System.out.println("Player " + currentPlayer.getSymbol() + " loses!");
+            if( currentPlayer.getSymbol().getSymbol() == 'X'){
+                System.out.println("Player " + Symbol.O.getSymbol() + " wins!");
+
+            }else{
+                System.out.println("Player " + Symbol.X.getSymbol() + " wins!");
+            }
             return true;
         }
         // Comprobar si el tablero está lleno


### PR DESCRIPTION
Description: This PR introduces a fix to the game's winner detection logic. Previously, the current player's token was incorrectly checked to determine the winner, resulting in an incorrect message at game end.

Changes made:

if (isLoser()) {
            if( currentPlayer.getSymbol().getSymbol() == 'X'){
                System.out.println("Player " + Symbol.O.getSymbol() + " wins!");

            }else{
                System.out.println("Player " + Symbol.X.getSymbol() + " wins!");
            }
            return true;
        }

The condition for checking if the current player is the loser (isLoser()) has been changed. Now, if the current player loses, the opposing player's token is correctly printed as the winner:
If the current player's token (currentPlayer) is 'X', the message will display player 'O' as the winner.
If the current player's token is 'O', the message will indicate that player 'X' has won.

Rationale: This change ensures that the game result message will always display the opposing player's token as the winner, thus improving accuracy and user experience in the game end flow.